### PR TITLE
Adapt the code to run on the review webhook

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1383,13 +1383,14 @@ exports.getRulesForLabels = async (issuesListLabelsOnIssueParams, client, rules)
 exports.getMaxReviewNumber = (rules) => rules.reduce((acc, rule) => (rule.reviews > acc ? rule.reviews : acc), 0);
 // Returns the repository information using provided gitHubEventPath
 exports.findRepositoryInformation = (gitHubEventPath, log, exit) => {
+    var _a;
     const payload = require(gitHubEventPath);
-    if (payload.number === undefined) {
-        exit.neutral('Action not triggered by a PullRequest action. PR ID is missing');
+    if (((_a = payload.pull_request) === null || _a === void 0 ? void 0 : _a.number) === undefined) {
+        exit.neutral('Action not triggered by a PullRequest review action. PR ID is missing');
     }
-    log.info(`Checking files list for PR#${payload.number}`);
+    log.info(`Checking labels for PR#${payload.pull_request.number}`);
     return {
-        issue_number: payload.number,
+        issue_number: payload.pull_request.number,
         owner: payload.repository.owner.login,
         repo: payload.repository.name,
     };
@@ -25477,7 +25478,7 @@ const args = {
         'pull_request.ready_for_review',
         'pull_request_review.submitted',
         'pull_request_review.edited',
-        'pull_request_review.dismissed',
+        'pull_request_review.dismissed'
     ],
     secrets: ['GITHUB_TOKEN'],
 };

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -14,12 +14,9 @@ import {
 
 const args: ToolkitOptions = {
   event: [
-    'pull_request.labeled',
-    'pull_request.unlabeled',
-    'pull_request.ready_for_review',
     'pull_request_review.submitted',
     'pull_request_review.edited',
-    'pull_request_review.dismissed'
+    'pull_request_review.dismissed',
   ],
   secrets: ['GITHUB_TOKEN'],
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,14 +36,14 @@ export const findRepositoryInformation = (
   exit: Exit
 ): IssuesListLabelsOnIssueParams => {
   const payload: WebhookPayloadWithRepository = require(gitHubEventPath)
-  if (payload.number === undefined) {
+  if (payload.pull_request?.number === undefined) {
     exit.neutral(
-      'Action not triggered by a PullRequest action. PR ID is missing'
+      'Action not triggered by a PullRequest review action. PR ID is missing'
     )
   }
-  log.info(`Checking files list for PR#${payload.number}`)
+  log.info(`Checking labels for PR#${payload.pull_request.number}`)
   return {
-    issue_number: payload.number,
+    issue_number: payload.pull_request.number,
     owner: payload.repository.owner.login,
     repo: payload.repository.name,
   }


### PR DESCRIPTION
This should fix #4 since the action actually doesn't need to run on PR modification but when reviews are submitted. This calls the action with the [pull_request_review](https://developer.github.com/webhooks/event-payloads/#pull_request_review) which is slightly different from the [pull_request](https://developer.github.com/webhooks/event-payloads/#pull_request) webhook payload and requires minimal modification.