### PR TITLE
Run on pull request review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,5 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: ./
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: "build-test"
 
-on: [pull_request]
+on:
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
 
 jobs:
 


### PR DESCRIPTION
The workflow is not meant to be run on opening pull requests anymore, so the test build was failing.
This will update the workflow to run just on reviews