### PR TITLE
feat: add synchronize event

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25478,7 +25478,8 @@ const args = {
         'pull_request.ready_for_review',
         'pull_request_review.submitted',
         'pull_request_review.edited',
-        'pull_request_review.dismissed'
+        'pull_request_review.dismissed',
+        'pull_request.synchronize'
     ],
     secrets: ['GITHUB_TOKEN'],
 };

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -17,6 +17,7 @@ const args: ToolkitOptions = {
     'pull_request_review.submitted',
     'pull_request_review.edited',
     'pull_request_review.dismissed',
+    'pull_request.synchronize',
   ],
   secrets: ['GITHUB_TOKEN'],
 }


### PR DESCRIPTION
## Problem:
The action could not be run when updating a PR from the main branch as _pull_request.synchronize_ couldn't be used and the following error was thrown:

> Event 'pull_request.synchronize' is not supported by this action.

## Solution:
Add `pull_request.synchronize` to the list of accepted events that can trigger the action. 