### PR TITLE
Streamline config and documentation

### DIFF
--- a/.github/label-requires-reviews.yml
+++ b/.github/label-requires-reviews.yml
@@ -1,4 +1,0 @@
-- label: "typescript"
-  reviews: 2
-- label: "migration"
-  reviews: 5

--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -9,6 +9,8 @@ on:
       - dismissed
   pull_request:
     types:
+      - opened
+      - reopened
       - synchronize
       - labeled
       - unlabeled
@@ -17,8 +19,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
+      
       - name: Require reviewers
         uses: ./       
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          rules_yaml: | # Input variables must be strings, here a multi-line yaml string
+            typescript: 2
+            migration: 5

--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -1,6 +1,4 @@
-# This workflow will set a number or reviewers depending on the tags
 name: Label Reviews
-# Trigger the workflow on pull requests
 on:
   pull_request_review:
     types:
@@ -16,15 +14,16 @@ on:
       - unlabeled
 jobs:
   require-reviewers:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      
-      - name: Require reviewers
+      # This workflow uses the current version of the action, so requires a checkout to make it run
+      - name: Checkout current version of action
+        uses: actions/checkout@v2
+      - name: Run action on current PR
         uses: ./       
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          rules_yaml: | # Input variables must be strings, here a multi-line yaml string
+          rules_yaml: |
             typescript: 2
             migration: 5

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,8 +36,24 @@ actions_toolkit_1.Toolkit.run(async (toolkit) => {
     var _a;
     toolkit.log.info('Running Action');
     const configPath = (_a = process.env.CONFIG_PATH) !== null && _a !== void 0 ? _a : '.github/label-requires-reviews.yml';
-    const rulesYaml = fs_1.default.readFileSync(configPath, 'utf8');
-    const rules = js_yaml_1.default.load(rulesYaml);
+    const rules = [];
+    const parseYamlRules = (rulesYaml) => {
+        const rulesObject = js_yaml_1.default.load(rulesYaml);
+        if (Array.isArray(rulesObject)) {
+            return rulesObject;
+        }
+        else {
+            return Object.entries(rulesObject).map(([key, value]) => {
+                return { label: key, reviews: value };
+            });
+        }
+    };
+    if (toolkit.inputs.rules_yaml) {
+        rules.push(...parseYamlRules(toolkit.inputs.rules_yaml));
+    }
+    if (fs_1.default.existsSync(configPath)) {
+        rules.push(...parseYamlRules(fs_1.default.readFileSync(configPath, 'utf8')));
+    }
     toolkit.log.info('Configured rules: ', rules);
     // Get the repository information
     if (!process.env.GITHUB_EVENT_PATH) {

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -37,8 +37,23 @@ Toolkit.run(async (toolkit: Toolkit) => {
   toolkit.log.info('Running Action')
   const configPath: string =
     process.env.CONFIG_PATH ?? '.github/label-requires-reviews.yml'
-  const rulesYaml = fs.readFileSync(configPath, 'utf8')
-  const rules: Rule[] = yaml.load(rulesYaml)
+  const rules: Rule[] = []
+  const parseYamlRules = (rulesYaml: String) => {
+    const rulesObject = yaml.load(rulesYaml)
+    if (Array.isArray(rulesObject)) {
+      return rulesObject
+    } else {
+      return Object.entries(rulesObject).map(([key, value]) => {
+        return { label: key, reviews: value }
+      })
+    }
+  }
+  if (toolkit.inputs.rules_yaml) {
+    rules.push(...parseYamlRules(toolkit.inputs.rules_yaml))
+  }
+  if (fs.existsSync(configPath)) {
+    rules.push(...parseYamlRules(fs.readFileSync(configPath, 'utf8')))
+  }
   toolkit.log.info('Configured rules: ', rules)
 
   // Get the repository information

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -38,7 +38,7 @@ Toolkit.run(async (toolkit: Toolkit) => {
   const configPath: string =
     process.env.CONFIG_PATH ?? '.github/label-requires-reviews.yml'
   const rules: Rule[] = []
-  const parseYamlRules = (rulesYaml: String) => {
+  const parseYamlRules = (rulesYaml: string) => {
     const rulesObject = yaml.load(rulesYaml)
     if (Array.isArray(rulesObject)) {
       return rulesObject


### PR DESCRIPTION
# Streamlined config

The current config mechanism based on a standalone yaml file containing the config
is somewhat tricky as it:
- requires the repository to be checked out to read the file
- the choice of the branch influences the logic, but is not necessarily the same branch as the one defining the workflow

In order to avoid a checkout altogether, this commit adds the possibility to define rules
in the workflow definition using the input variable `rules_yaml`

```yaml
jobs:
  require-reviewers:
    steps:
      - name: Require reviewers
        uses: travelperk/label-requires-reviews-action@master
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          rules_yaml: | # Input variables must be strings, here a multi-line yaml string
            typescript: 2
            migration: 5
```

Furthermore this commit adds support for the shorter
```yaml
typescript: 2
migration: 5
```
syntax on top of the existing one
```yaml
- label: typescript
  reviews: 2
- label: migration
  reviews: 5
```

All those changes are made in a backwards compatible fashion (I leave it up to the current maintainers to make deprecation decisions if desired)

# Streamlined documentation

- [x] Document shorter definition of rules in workflow (without checkout)
- [x] Provide a pointer to other supported rule definitions (older README)
- [x] No need to ask users to create a token, github automatically provides `secrets.GITHUB_TOKEN`
