### PR TITLE
Document concrete check skip example

### DIFF
--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -14,6 +14,7 @@ on:
       - unlabeled
 jobs:
   require-reviewers:
+    # Don't skip this job as it's meant to be run for every PR, regardless of its labels
     runs-on: ubuntu-latest
     steps:
       # This workflow uses the current version of the action, so requires a checkout to make it run

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 
 `rules_yaml` is a (yaml-formatted multi-line) string of pairs `label`: `# of approving reviewers`. With the example configuration above, this check will fail on a Pull Request that has the `typescript` label until two or more reviewers have approved it. If instead the Pull Request has the `migration` label it will require five, in case both labels are present it will also require five.
 
-`rules_yaml` also supports an array of objects format, as well as being defined in an external file (but then the workflow also needs a checkout step), see documentation of earlier versions https://github.com/travelperk/label-requires-reviews-action/tree/1.3.0#readme.
+`rules_yaml` also supports an array of objects format, as well as being defined in an external file (but then the workflow also needs a checkout step), see documentation of [versions earlier than `1.3.0`](https://github.com/travelperk/label-requires-reviews-action/tree/1.2.1#readme).
 ### Enforce the requirement
 To make this check mandatory you need to specify it on the `Branch protection rule` section of the repository settings like the example:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ on:
       - dismissed
 jobs:
   require-reviewers:
+    # Optional: skip check if no relevant label is present
+    # This needs to be kept in sync with the labels being checked
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'typescript') || contains(github.event.pull_request.labels.*.name, 'migration') }}
+
     runs-on: ubuntu-latest
     steps:
       - name: Require-reviewers
@@ -49,9 +53,3 @@ According to this configuration, the `master` branch is protected by the option 
 
 By checking `Require status checks to pass before merging` and `require-reviewers` anytime the Pull Request gets a new review this action will fire and the Pull Request is labeled with one of the labels that require more than one approving review blocking the possibility of merging until this label required number of approving reviews is reached.
 
-### Saving tip
-Since Github Workflow [jobs can have conditionals](https://github.blog/changelog/2019-10-01-github-actions-new-workflow-syntax-features/), and in the workflow you can [directly access some action metadata](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts).
-
-You can avoid checking out the code and running this action if you know the issue does not contain any of the labels that will trigger it, that will set the action as skipped and will never run.
-
-The drawback is that the list of labels will be duplicated, but you can save a lot of actions time.


### PR DESCRIPTION
- [x] Include check skipping in the example workflow instead of saying in the "saving tip" that it can be done.
- [x] Adjust pointer to older doc in readme as `1.2.1` (that slipped through as a wrong version in the previous PR)