### PR TITLE
Fix reference to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require-reviewers
-        uses: travelperk/label-requires-reviews-action@v1.3.0
+        uses: travelperk/label-requires-reviews-action@1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This repository uses tags without `v` in front. See https://github.com/travelperk/label-requires-reviews-action/tags

Thus, the MWE in the README.md does not work

![image](https://github.com/travelperk/label-requires-reviews-action/assets/1366654/92bfb626-982f-405c-93b1-8daf467beea9)

(https://github.com/travelperk/label-requires-reviews-action/tree/v1.3.0/ is 404)

If using without `v` it works:

![image](https://github.com/travelperk/label-requires-reviews-action/assets/1366654/7d353622-4c0a-4adc-9af0-9944aee3b233)

(https://github.com/travelperk/label-requires-reviews-action/tree/1.3.0/ is OK)